### PR TITLE
FIX - Excluding folders without .ds ending

### DIFF
--- a/nih2mne/make_meg_bids.py
+++ b/nih2mne/make_meg_bids.py
@@ -70,7 +70,7 @@ def sessdir2taskrundict(session_dir=None):
     #Verify that these are meg datasets
     tmp_=[]
     for dset in dsets:
-        if os.path.splitext(dset)[-1] != '.ds':
+        if not dset.endswith('.ds'):
             logger.warning(f'{dset} does not end in .ds and will be ignored')
         else:
             tmp_.append(dset)


### PR DESCRIPTION
This fixes a problem where folders without a suffix ending are not excluded.