### PR TITLE
Only consider "cardinal" fiducials

### DIFF
--- a/nih2mne/calc_mnetrans.py
+++ b/nih2mne/calc_mnetrans.py
@@ -357,7 +357,8 @@ def write_mne_trans(mne_fids_path=None, dsname=None,
         raw = mne.io.read_raw_kit(dsname, preload=False)
         
     _tmp = raw.info['dig']
-    _raw_fids_order = [str(i['ident']).split('_')[-1].replace(')','') for i in _tmp]
+    _raw_fids_type = [str(i['kind']).split('_')[-1].replace(')','') for i in _tmp]
+    _raw_fids_order = [str(i['ident']).split('_')[-1].replace(')','') for n,i in enumerate(_tmp) if 'CARDINAL' in _raw_fids_type[n] ]    
     reordering=[]
     for i in _raw_fids_order:
         print(i)


### PR DESCRIPTION
Some MEG files have extra elements in raw.info['dig'] (see example below). This change considers only the correct fiducials points. 

Example with extra elements:  
[<DigPoint |     Nasion : (-0.0, 90.5, 0.0) mm      : head frame>,
 <DigPoint |        LPA : (-69.3, 0.0, 0.0) mm      : head frame>,
 <DigPoint |        RPA : (79.1, -0.0, 0.0) mm      : head frame>,
 <DigPoint | Extra #301 : (-21.3, -98.2, 73.6) mm   : head frame>,
 <DigPoint | Extra #302 : (41.5, -94.8, 73.6) mm    : head frame>,
 <DigPoint | Extra #303 : (75.6, -75.0, 44.5) mm    : head frame>,
 <DigPoint | Extra #304 : (-38.6, -94.2, 14.2) mm   : head frame>]